### PR TITLE
New gem feature to fetch page insights.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.1.1  - 2017/06/29
+
+* [FEATURE] Add `Fb::Page#insights`
+
 ## 0.1.0  - 2017/06/29
 
 * [FEATURE] Add `Fb::Auth#url`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Fb::Auth can authenticate a Facebook user and return an access token with permis
 [![Gem Version](http://img.shields.io/gem/v/fb-auth.svg)](http://rubygems.org/gems/fb-auth)
 
 The **source code** is available on [GitHub](https://github.com/Fullscreen/fb-auth) and the **documentation** on [RubyDoc](http://www.rubydoc.info/gems/fb-auth/frames).
-
 ### Installing and Configuring Fb::Auth
 
 First, add fb-auth to your Gemfile:
@@ -67,7 +66,7 @@ array of type Fb::Page, each with an id and name.
 ```ruby
 access_token = Fb::Auth.new(redirect_uri: redirect_uri, code: code).access_token
 Fb::User.new(access_token).pages
- # => [#<Fb::Page: @name="sample1", @id="1234">, #<Fb::Page: @name="sample2", @id="5678">]
+ # => [#<Fb::Page: id="1234", name="sample1">, #<Fb::Page: id="5678", name="sample2">]
 ```
 
 Fb::User#email
@@ -80,6 +79,21 @@ access_token = Fb::Auth.new(redirect_uri: redirect_uri, code: code).access_token
 Fb::User.new(access_token).email
  # => "john.smith@example.com"
 ```
+
+Fb::Page#insights
+---------------------
+
+For each page object created, you can get these pre-defined metrics: page_views_total, page_fan_adds_unique, page_engaged_users, page_video_views. The insights method will fetch the cumulative value of these metrics 7 days prior to two weeks ago (e.g. if today is July 6, 2017, the value of the metric will be for the 7 days prior to and ending on June 22, 2017). The selection of metrics and aggregate period will be options in a future patch.
+
+```ruby
+Fb::User.new('token').pages.insights
+ # => {"page_fan_adds_unique"=>#<Fb::Metric:0x123abc
+ @name="page_fans", @description="Weekly: The
+ number of new people who have liked your Page (Unique Users)",
+ @value=123>,..}
+```
+
+A full list of page/insights metrics are available at [metrics](https://developers.facebook.com/docs/graph-api/reference/v2.9/insights#availmetrics).
 
 Fb::Error
 -------------

--- a/lib/fb/auth/version.rb
+++ b/lib/fb/auth/version.rb
@@ -2,6 +2,6 @@ module Fb
   class Auth
     # @return [String] the SemVer-compatible gem version.
     # @see http://semver.org
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/lib/fb/metric.rb
+++ b/lib/fb/metric.rb
@@ -1,0 +1,35 @@
+# Ruby client to authenticate a Facebook user.
+# @see http://www.rubydoc.info/gems/Fb/
+module Fb
+  # Fb::Metric reprensents a Facebook page's metric.
+  # For a list of all available metrics, refer to:
+  # @see https://developers.facebook.com/docs/graph-api/reference/v2.9/insights
+  # Provides methods to read name, description, and value.
+  class Metric
+
+    # @return [String] the name of the metric (e.g. page_fans).
+    attr_reader :name
+
+    # @return [String] a description for the metric.
+    attr_reader :description
+
+    # @return [Integer] the value of the metric when last requested.
+    attr_reader :value
+
+    # @param [Hash] options the options to initialize an instance of Fb::Metric.
+    # @option [String] :name of the metric.
+    # @option [String] :title of the metric.
+    # @option [String] :description of the metric.
+    # @option [Integer] :value of this metric when last requested.
+    def initialize(options = {})
+      @name = options["name"]
+      @description = options["description"]
+      @value = options["values"].first["value"]
+    end
+
+    # @return [String] the representation of the metric.
+    def to_s
+      "#<#{self.class.name} name=#{@name}, description=#{@description}, value=#{@value}>"
+    end
+  end
+end

--- a/lib/fb/page.rb
+++ b/lib/fb/page.rb
@@ -1,4 +1,6 @@
 require 'date'
+require 'fb/request'
+require 'fb/metric'
 # Ruby client to authenticate a Facebook user.
 # @see http://www.rubydoc.info/gems/Fb/
 module Fb
@@ -17,12 +19,44 @@ module Fb
     def initialize(options = {})
       @name = options["name"]
       @id = options["id"]
+      @user = options["user"]
+    end
+
+    # @return [Hash] a collection of metrics with metric name as key
+    #   and metric object as value.
+    # @example
+    #   Fb::User.new('token').pages.insights
+    #   => {"page_fan_adds_unique"=>#<Fb::Metric:0x123abc
+    #   @name="page_fans", @description="Weekly: The
+    #   number of new people who have liked your Page (Unique Users)",
+    #   @value=123>,..}
+    def insights
+      @insights ||= begin
+        response_body = Fb::Request.new(
+          path: "/v2.9/#{@id}/insights",
+          params: insights_params).run
+        response_body["data"].map do |metric_data|
+          [metric_data["name"], Fb::Metric.new(metric_data)]
+        end.to_h
+      end
     end
 
     # @return [String] the representation of the page.
     def to_s
       "#<#{self.class.name} id=#{@id}, name=#{@name}>"
     end
+
+  private
+
+    def insights_params
+      {}.tap do |params|
+        params[:since] = (Time.now - 14 * 86400).strftime("%Y-%m-%d")
+        params[:until] = Date.parse(params[:since]) + 1
+        params[:period] = :week
+        params[:metric] = 'page_views_total,page_fan_adds_unique,
+          page_engaged_users,page_video_views'
+        params[:access_token] = @user.send(:access_token)
+      end
+    end
   end
 end
-

--- a/lib/fb/user.rb
+++ b/lib/fb/user.rb
@@ -25,9 +25,12 @@ module Fb
         response_body = Fb::Request.new(path: '/me/accounts',
           params: {access_token: @access_token}).run
         response_body["data"].map do |page_data|
-          Fb::Page.new page_data
+          Fb::Page.new page_data.merge('user' => self)
         end
       end
     end
+
+  private
+    attr_reader :access_token
   end
 end

--- a/spec/metrics/to_s_spec.rb
+++ b/spec/metrics/to_s_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe 'Fb::Metric#to_s' do
+  metric = Fb::Metric.new "name"=>"test", "description"=>"test metric", "values"=>[{"value"=>1234}]
+
+  it 'returns the string represenation' do
+    expect(metric.to_s).to eq '#<Fb::Metric name=test, description=test metric, value=1234>'
+  end
+end

--- a/spec/pages/insights_spec.rb
+++ b/spec/pages/insights_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe 'Fb::Page#insights' do
+  context 'given an invalid user access token' do
+    user = Fb::User.new 'invalid_token'
+    page = Fb::Page.new({"name"=>"test", "id"=>"1234", "user"=>user})
+
+    it 'raises Fb::Error' do
+      expect{page.insights}.to raise_error Fb::Error
+    end
+  end
+
+  context 'given a valid user access token and an existing Facebook page' do
+    user = Fb::User.new ENV['FB_TEST_ACCESS_TOKEN']
+    page = Fb::Page.new({"name" => "Games",
+      "id" => "872965469547237",
+      "user" => user})
+
+    it 'returns a hash of metrics' do
+      expect(page.insights).to be_a(Hash)
+      page.insights.each do |key, metric|
+        expect(metric).to be_a Fb::Metric
+        expect(key).to eq metric.name
+        expect(metric.name).to be_a(String)
+        expect(metric.description).to be_a(String)
+        expect(metric.value).to be_a(Integer)
+      end
+    end
+  end
+end

--- a/spec/pages/to_s_spec.rb
+++ b/spec/pages/to_s_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'Fb::Auth#to_s' do
+RSpec.describe 'Fb::Page#to_s' do
   page = Fb::Page.new("name"=>"test", "id"=>"1234")
 
   it 'returns the string represenation' do

--- a/spec/users/pages_spec.rb
+++ b/spec/users/pages_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Fb::User#pages' do
-  context 'given an invalid valid access token' do
+  context 'given an invalid access token' do
     it 'raises Fb::Error' do
       user = Fb::User.new 'invalid_token'
       expect{user.pages}.to raise_error Fb::Error


### PR DESCRIPTION
Fb::Page#insights allows users to fetch the title, description, and value
on a set of predefined insights. Request parameters (period, since, until)
are also predefined and will be implemented as optional parameters in a later patch.