### PR TITLE
Set scope as variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,19 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
-## 1.0.0  - 2017/07/24
+## Unreleased
+
+* [ENHANCEMENT] Set scope as variable for `Fb::Auth#url`
+
+## 1.0.0.alpha3  - 2017/08/31
+
+* [FEATURE] Add Fb::Auth#revoke
+
+## 1.0.0.alpha2  - 2017/07/25
+
+* [ENHANCEMENT] Set scope `'email,pages_show_list,read_insights'` for `Fb::Auth#url`
+
+## 1.0.0.alpha1  - 2017/07/24
 
 This library was originally intended to provide methods to authenticate but
 has grown to include other methods to configure, get posts, insights etc.
@@ -19,7 +31,7 @@ Most of those methods have been extracted into separate libraries.
 ## 0.1.3  - 2017/07/20
 
 * [BUGFIX] Fixed `require` statement not loading for some classes.
-* [BUGFIX] Fixed typo (it's client_secret, not client_id)
+* [BUGFIX] Fixed typo (it's `client_secret`, not `client_id`)
 
 ## 0.1.2  - 2017/07/11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
-## Unreleased
+## 1.0.0.alpha4  - 2017/12/18
 
 * [ENHANCEMENT] Set scope as variable for `Fb::Auth#url`
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ authenticate with their Facebook account in order to use your application:
 
 ```ruby
 redirect_uri = 'https://example.com/auth' # REPLACE WITH REAL ONE
-Fb::Auth.new(redirect_uri: redirect_uri).url
+Fb::Auth.new(redirect_uri: redirect_uri, scope: ["manage_pages"]).url
  # => https://www.facebook.com/dialog/oauth?client_id=...&scope=manage_pages&redirect_uri=https%3A%2F%2Fexample.com%2Fauth
 ```
 
-Note that access is always requested with permission to access email,
-manage pages and read insights.
+Note that access is requested with permission to access email, manage pages,
+read insights, et cetera. See https://developers.facebook.com/docs/facebook-login/permissions
 
 Fb::Auth#access_token
 ---------------------
@@ -61,10 +61,7 @@ Fb::Auth.new(redirect_uri: redirect_uri, code: code).access_token
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies.
-If you would like to run tests for Fb::Auth, please obtain a long-term access token that manages at least one page
-and has permission to read your Facebook email (set scope to include `email`, `pages_show_list`, & `read_insights`). Then set the token as
-as an environment variable:
+After checking out the repo, run `bin/setup` to install dependencies. If you would like to run tests for Fb::Auth, please obtain a long-term access token that manages at least one page and has permission to read your Facebook email. (set scope to include `email`, `manage_pages`, `read_insights`.) Then set the token as an environment variable:
 
     export FB_TEST_ACCESS_TOKEN="YourToken"
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,7 @@ Fb::Auth.new(redirect_uri: redirect_uri, code: code).access_token
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. If you would like to run tests for Fb::Auth, please obtain a long-term access token that manages at least one page and has permission to read your Facebook email. (set scope to include `email`, `manage_pages`, `read_insights`.) Then set the token as an environment variable:
-
-    export FB_TEST_ACCESS_TOKEN="YourToken"
+After checking out the repo, run `bin/setup` to install dependencies.
 
 Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
@@ -72,7 +70,6 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/Fullscreen/fb-auth. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
-
 
 ## License
 

--- a/lib/fb/auth.rb
+++ b/lib/fb/auth.rb
@@ -11,10 +11,13 @@ module Fb
     #   after they have completed the Facebook OAuth flow.
     # @option [String] :code A single-use authorization code provided
     #   by Facebook OAuth to obtain an access token.
+    # @option [String] :refresh_token
+    # @option [Array<String>] :scope
     def initialize(options = {})
       @redirect_uri = options[:redirect_uri]
       @code = options[:code]
       @refresh_token = options[:refresh_token]
+      @scope = options[:scope]
     end
 
     # @return [Boolean] whether the authentication was revoked.
@@ -46,7 +49,7 @@ module Fb
       {}.tap do |params|
         params[:client_id] = Fb.configuration.client_id
         params[:redirect_uri] = @redirect_uri
-        params[:scope] = 'email,pages_show_list,read_insights'
+        params[:scope] = Array(@scope).join(",")
       end
     end
 

--- a/lib/fb/auth/version.rb
+++ b/lib/fb/auth/version.rb
@@ -2,6 +2,6 @@ module Fb
   class Auth
     # @return [String] the SemVer-compatible gem version.
     # @see http://semver.org
-    VERSION = '1.0.0.alpha3'
+    VERSION = '1.0.0.alpha4'
   end
 end

--- a/spec/url_spec.rb
+++ b/spec/url_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe 'Fb::Auth#url' do
   context 'given a valid redirect URI' do
-    auth = Fb::Auth.new redirect_uri: 'http://example.com'
+    auth = Fb::Auth.new redirect_uri: 'http://example.com', scope: ['email', 'pages_show_list', 'read_insights']
 
     it 'returns a link to Facebook authentication flow' do
       expect(auth.url).to start_with 'https://www.facebook.com/dialog/oauth'


### PR DESCRIPTION
`Fb::Auth#url` generates a url address to get (code and) token from Facebook. Sometimes we need different permissions for that token. So I think it's good idea to set it as a variable.